### PR TITLE
change path detection logic

### DIFF
--- a/svgdigitizer/svgdigitizer.py
+++ b/svgdigitizer/svgdigitizer.py
@@ -166,10 +166,7 @@ class SvgData:
             if path.parentNode.nodeName != 'g' or path.parentNode.getAttribute("inkscape:groupmode") == 'layer' or len(path.parentNode.getElementsByTagName("path")) > 1:
                 paths.append(path)
 
-        xypaths = {path.getAttribute('id'): self.parse_pathstring(path.getAttribute('d')) for path in paths}
-
-        return xypaths
-    
+        return {path.getAttribute('id'): self.parse_pathstring(path.getAttribute('d')) for path in paths}
 
     def parse_pathstring(self, path_string):
         path = parse_path(path_string)

--- a/svgdigitizer/svgdigitizer.py
+++ b/svgdigitizer/svgdigitizer.py
@@ -156,17 +156,19 @@ class SvgData:
         return np.array([xnorm, ynorm])
 
     def get_paths(self):
-        paths = self.doc.getElementsByTagName("path")
-        # only take paths into account which are not in groups
-        # Note that layers are groups
-        path_strings = []
-        for path in paths:
-            if path.parentNode.nodeName != 'g' or path.parentNode.getAttribute("inkscape:groupmode") == 'layer':
-                path_strings.append((path.getAttribute('id'), path.getAttribute('d')))
+        # Only take paths into account which are not in groups since those are
+        # the paths pointing to labels on the axes.
+        # This is complicated by the fact that layers as created by inkscape
+        # are also groups. Though such layers have `inkscape:groupmode` set,
+        # this attribute goes away when exporting to plain SVG.
+        paths = []
+        for path in self.doc.getElementsByTagName("path"):
+            if path.parentNode.nodeName != 'g' or path.parentNode.getAttribute("inkscape:groupmode") == 'layer' or len(path.parentNode.getElementsByTagName("path")) > 1:
+                paths.append(path)
 
-        xypaths_all = {path_string[0]: self.parse_pathstring(path_string[1]) for path_string in path_strings}
+        xypaths = {path.getAttribute('id'): self.parse_pathstring(path.getAttribute('d')) for path in paths}
 
-        return xypaths_all    
+        return xypaths
     
 
     def parse_pathstring(self, path_string):

--- a/svgdigitizer/svgdigitizer.py
+++ b/svgdigitizer/svgdigitizer.py
@@ -28,11 +28,8 @@ class SvgData:
         for axis in ['x','y']:
             self.trafo[axis] = self.get_trafo(axis)
 
-        
-        self.doc.unlink()
         self.get_parsed()
         self.create_df()
-        
     
     def get_points(self):
         '''Creates:

--- a/svgdigitizer/svgdigitizer.py
+++ b/svgdigitizer/svgdigitizer.py
@@ -21,8 +21,6 @@ class SvgData:
         
         self.doc = minidom.parse(self.filename)
 
-        self.figpaths = self.get_paths()
-        
         self.ref_points, self.real_points = self.get_points()
         
 
@@ -132,7 +130,7 @@ class SvgData:
     def get_parsed(self):
         '''cuve function'''
         self.allresults = {}
-        for pathid, pvals in self.figpaths.items():
+        for pathid, pvals in self.paths.items():
             self.allresults[pathid] = self.get_real_values(pvals)
     
 
@@ -155,18 +153,27 @@ class SvgData:
         ynorm = self.trafo['y'](xpathdata[:, 1])
         return np.array([xnorm, ynorm])
 
-    def get_paths(self):
-        # Only take paths into account which are not in groups since those are
-        # the paths pointing to labels on the axes.
-        # This is complicated by the fact that layers as created by inkscape
-        # are also groups. Though such layers have `inkscape:groupmode` set,
-        # this attribute goes away when exporting to plain SVG.
-        paths = []
-        for path in self.doc.getElementsByTagName("path"):
-            if path.parentNode.nodeName != 'g' or path.parentNode.getAttribute("inkscape:groupmode") == 'layer' or len(path.parentNode.getElementsByTagName("path")) > 1:
-                paths.append(path)
-
-        return {path.getAttribute('id'): self.parse_pathstring(path.getAttribute('d')) for path in paths}
+    @cached_property
+    def paths(self):
+        r"""
+        Return the paths that are tracing plots in the SVG, i.e., return all
+        the `<path>` tags that are not used for other purposes such as pointing
+        to axis labels.
+        """
+        return {
+            path.getAttribute('id'): self.parse_pathstring(path.getAttribute('d'))
+            for path in self.doc.getElementsByTagName("path")
+            # Only take paths into account which are not in groups since those are
+            # the paths pointing to labels on the axes.
+            if path.parentNode.nodeName != 'g' or
+                # This is complicated by the fact that layers as created by inkscape
+                # are also groups. Such layers have the 'inkscape:groupmode' set.
+                path.parentNode.getAttribute("inkscape:groupmode") == 'layer' or
+                # But this attribute goes away when exporting to plain SVG. In
+                # such case, we recover layers as the groups that contain more
+                # than one path.
+                len(path.parentNode.getElementsByTagName("path")) > 1
+        }
 
     def parse_pathstring(self, path_string):
         path = parse_path(path_string)


### PR DESCRIPTION
since we cannot reliably detect inkscape layers, we now treat anything
containing more than one path as a layer.