### PR TITLE
Update readme for CLI 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Options:
   --help  Show this message and exit.
 
 Commands:
+  cv
   digitize
   paginate
   plot
@@ -33,6 +34,8 @@ $ svgdigitizer digitize test/data/Ni111_NaOH_Beden1985_Fig2c.svg
 [creates test/data/Ni111_NaOH_Beden1985_Fig2c.csv]
 $ svgdigitizer paginate <pdf file>
 [paginates the pdf file]
+$ svgdigitizer cv test/data/Ni111_NaOH_Beden1985_Fig2c.svg
+[creates test/data/Ni111_NaOH_Beden1985_Fig2c.csv]
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -29,13 +29,11 @@ Commands:
 $ svgdigitizer plot test/data/Ni111_NaOH_Beden1985_Fig2c.svg
 [displays a plot]
 $ svgdigitizer digitize test/data/Ni111_NaOH_Beden1985_Fig2c.svg
-[creates test/data/Ni111_NaOH_Beden1985_Fig2c.csv]
-$ svgdigitizer digitize test/data/Ni111_NaOH_Beden1985_Fig2c.svg
-[creates test/data/Ni111_NaOH_Beden1985_Fig2c.csv]
+[creates test/data/Ni111_NaOH_Beden1985_Fig2c.csv with axes x and y]
 $ svgdigitizer paginate <pdf file>
 [paginates the pdf file]
 $ svgdigitizer cv test/data/Ni111_NaOH_Beden1985_Fig2c.svg
-[creates test/data/Ni111_NaOH_Beden1985_Fig2c.csv]
+[creates test/data/Ni111_NaOH_Beden1985_Fig2c.csv with axis t, U and I or j]
 ```
 
 ## API


### PR DESCRIPTION
I updated the CLI readme to include the CV Option.

Are the examples provided in the readme useful?
For example `digitize` and `cv` show the same results.

Furthermore, should the options also be shown in the examples?