### PR TITLE
run Python linter in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,11 @@ jobs:
         run: |
           mamba env update --quiet -n test -f environment.yml
           conda list
+      - name: pylint
+        shell: bash -l {0}
+        run: |
+          # Currently, we ignore the verdict of the linter, we need to fix the lint first, see #83.
+          pylint svgdigitizer || true
       - name: black
         shell: bash -l {0}
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pycodestyle:
+  python-linter:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -20,7 +20,5 @@ jobs:
         run: |
           mamba env update --quiet -n test -f environment.yml
           conda list
-      - name: pycodestyle
-        shell: bash -l {0}
-        run: |
-          pycodestyle svgdigitizer --max-line-length=256
+      - name: lint
+        uses: sunnysid3up/python-linter@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,5 +20,11 @@ jobs:
         run: |
           mamba env update --quiet -n test -f environment.yml
           conda list
-      - name: lint
-        uses: sunnysid3up/python-linter@master
+      - name: black
+        shell: bash -l {0}
+        run: |
+          black --check --diff svgdigitizer
+      - name: isort
+        shell: bash -l {0}
+        run: |
+          isort svgdigitizer

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,4 +27,4 @@ jobs:
       - name: isort
         shell: bash -l {0}
         run: |
-          isort svgdigitizer
+          isort --check --diff svgdigitizer

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[FORMAT]
+max-line-length=256

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,9 @@ dependencies:
   - astropy
   - sphinx
   - myst-parser
+  - pylint
+  - black
+  - isort
   - pip
   - pip:
     - linkchecker

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,6 @@ dependencies:
   - pdf2image
   - svgwrite
   - svgpathtools
-  - pycodestyle
   - pytest
   - scipy
   - astropy

--- a/svgdigitizer/__main__.py
+++ b/svgdigitizer/__main__.py
@@ -65,8 +65,8 @@ def plot(svg, sampling_interval):
         ...     invoke(cli, "plot", os.path.join(directory, "xy.svg"))
 
     """
-    from svgdigitizer.svgplot import SVGPlot
     from svgdigitizer.svg import SVG
+    from svgdigitizer.svgplot import SVGPlot
 
     SVGPlot(SVG(svg), sampling_interval=sampling_interval).plot()
 
@@ -80,8 +80,8 @@ def plot(svg, sampling_interval):
 )
 @click.argument("svg", type=click.Path(exists=True))
 def digitize(svg, sampling_interval):
-    from svgdigitizer.svgplot import SVGPlot
     from svgdigitizer.svg import SVG
+    from svgdigitizer.svgplot import SVGPlot
 
     plot = SVGPlot(SVG(open(svg, "rb")), sampling_interval=sampling_interval)
     from pathlib import Path
@@ -146,13 +146,14 @@ def cv(svg, sampling_interval, metadata, package, outdir):
         ...     invoke(cli, "cv", os.path.join(directory, "xy_rate.svg"))
 
     """
+    import os.path
+
     import yaml
     from astropy import units as u
-    from svgdigitizer.svgplot import SVGPlot
-    from svgdigitizer.svg import SVG
-    from svgdigitizer.electrochemistry.cv import CV
 
-    import os.path
+    from svgdigitizer.electrochemistry.cv import CV
+    from svgdigitizer.svg import SVG
+    from svgdigitizer.svgplot import SVGPlot
 
     if outdir is None:
         outdir = os.path.dirname(svg)
@@ -191,7 +192,7 @@ def cv(svg, sampling_interval, metadata, package, outdir):
         p = Package(cv.metadata, base_path=outdir)
         p.infer(csvname)
 
-    from datetime import datetime, date
+    from datetime import date, datetime
 
     def defaultconverter(o):
         if isinstance(o, (datetime, date)):
@@ -211,10 +212,10 @@ def cv(svg, sampling_interval, metadata, package, outdir):
 @click.option("--onlypng", is_flag=True, help="Only produce png files")
 @click.argument("pdf")
 def paginate(onlypng, pdf):
-    from pdf2image import convert_from_path
     import svgwrite
-    from svgwrite.extensions.inkscape import Inkscape
+    from pdf2image import convert_from_path
     from PIL import Image
+    from svgwrite.extensions.inkscape import Inkscape
 
     basename = pdf.split(".")[0]
     pages = convert_from_path(pdf, dpi=600)

--- a/svgdigitizer/__main__.py
+++ b/svgdigitizer/__main__.py
@@ -40,13 +40,19 @@ EXAMPLES::
 import click
 
 
-@click.group(help=__doc__.split('EXAMPLES')[0])
-def cli(): pass
+@click.group(help=__doc__.split("EXAMPLES")[0])
+def cli():
+    pass
 
 
 @click.command()
-@click.option('--sampling_interval', type=float, default=None, help='Sampling interval on the x-axis.')
-@click.argument('svg', type=click.File('rb'))
+@click.option(
+    "--sampling_interval",
+    type=float,
+    default=None,
+    help="Sampling interval on the x-axis.",
+)
+@click.argument("svg", type=click.File("rb"))
 def plot(svg, sampling_interval):
     r"""
     Display a plot of the data traced in an SVG.
@@ -61,26 +67,46 @@ def plot(svg, sampling_interval):
     """
     from svgdigitizer.svgplot import SVGPlot
     from svgdigitizer.svg import SVG
+
     SVGPlot(SVG(svg), sampling_interval=sampling_interval).plot()
 
 
 @click.command()
-@click.option('--sampling_interval', type=float, default=None, help='Sampling interval on the x-axis.')
-@click.argument('svg', type=click.Path(exists=True))
+@click.option(
+    "--sampling_interval",
+    type=float,
+    default=None,
+    help="Sampling interval on the x-axis.",
+)
+@click.argument("svg", type=click.Path(exists=True))
 def digitize(svg, sampling_interval):
     from svgdigitizer.svgplot import SVGPlot
     from svgdigitizer.svg import SVG
-    plot = SVGPlot(SVG(open(svg, 'rb')), sampling_interval=sampling_interval)
+
+    plot = SVGPlot(SVG(open(svg, "rb")), sampling_interval=sampling_interval)
     from pathlib import Path
-    plot.df.to_csv(Path(svg).with_suffix('.csv'), index=False)
+
+    plot.df.to_csv(Path(svg).with_suffix(".csv"), index=False)
 
 
 @click.command()
-@click.option('--sampling_interval', type=float, default=None, help='sampling interval on the x-axis in volt (V)')
-@click.option('--metadata', type=click.File("rb"), default=None, help='yaml file with metadata')
-@click.option('--package', is_flag=True, help='create .json in data package format')
-@click.option('--outdir', type=click.Path(file_okay=False), default=None, help='write output files to this directory')
-@click.argument('svg', type=click.Path(exists=True))
+@click.option(
+    "--sampling_interval",
+    type=float,
+    default=None,
+    help="sampling interval on the x-axis in volt (V)",
+)
+@click.option(
+    "--metadata", type=click.File("rb"), default=None, help="yaml file with metadata"
+)
+@click.option("--package", is_flag=True, help="create .json in data package format")
+@click.option(
+    "--outdir",
+    type=click.Path(file_okay=False),
+    default=None,
+    help="write output files to this directory",
+)
+@click.argument("svg", type=click.Path(exists=True))
 def cv(svg, sampling_interval, metadata, package, outdir):
     r"""
     Create a CSV and YAML metadata file for inclusion in the echemdb.
@@ -127,16 +153,18 @@ def cv(svg, sampling_interval, metadata, package, outdir):
     from svgdigitizer.electrochemistry.cv import CV
 
     import os.path
+
     if outdir is None:
         outdir = os.path.dirname(svg)
     if outdir.strip() == "":
         outdir = "."
 
     import os
+
     os.makedirs(str(outdir), exist_ok=True)
 
     # Determine unit of the voltage scale.
-    cv = CV(SVGPlot(SVG(open(svg, 'rb'))))
+    cv = CV(SVGPlot(SVG(open(svg, "rb"))))
     xunit = CV.get_axis_unit(cv.x_label.unit)
     if sampling_interval is not None and xunit != u.V:
         # Determine conversion factor to volts.
@@ -146,15 +174,20 @@ def cv(svg, sampling_interval, metadata, package, outdir):
     if metadata:
         metadata = yaml.load(metadata, Loader=yaml.SafeLoader)
 
-    cv = CV(SVGPlot(SVG(open(svg, 'rb')), sampling_interval=sampling_interval), metadata=metadata)
+    cv = CV(
+        SVGPlot(SVG(open(svg, "rb")), sampling_interval=sampling_interval),
+        metadata=metadata,
+    )
 
     from pathlib import Path
-    csvname = Path(svg).with_suffix('.csv').name
+
+    csvname = Path(svg).with_suffix(".csv").name
 
     cv.df.to_csv(os.path.join(outdir, csvname), index=False)
 
     if package:
         from datapackage import Package
+
         p = Package(cv.metadata, base_path=outdir)
         p.infer(csvname)
 
@@ -165,35 +198,53 @@ def cv(svg, sampling_interval, metadata, package, outdir):
             return o.__str__()
 
     import json
-    with open(os.path.join(outdir, Path(svg).with_suffix('.json').name), "w") as outfile:
-        json.dump(p.descriptor if package else cv.metadata, outfile, default=defaultconverter)
+
+    with open(
+        os.path.join(outdir, Path(svg).with_suffix(".json").name), "w"
+    ) as outfile:
+        json.dump(
+            p.descriptor if package else cv.metadata, outfile, default=defaultconverter
+        )
 
 
 @click.command()
-@click.option('--onlypng', is_flag=True, help='Only produce png files')
-@click.argument('pdf')
+@click.option("--onlypng", is_flag=True, help="Only produce png files")
+@click.argument("pdf")
 def paginate(onlypng, pdf):
     from pdf2image import convert_from_path
     import svgwrite
     from svgwrite.extensions.inkscape import Inkscape
     from PIL import Image
-    basename = pdf.split('.')[0]
+
+    basename = pdf.split(".")[0]
     pages = convert_from_path(pdf, dpi=600)
     for idx, page in enumerate(pages):
-        base_image_path = f'{basename}_p{idx}'
-        page.save(f'{base_image_path}.png', 'PNG')
+        base_image_path = f"{basename}_p{idx}"
+        page.save(f"{base_image_path}.png", "PNG")
         if not onlypng:
-            image = Image.open(f'{base_image_path}.png')
+            image = Image.open(f"{base_image_path}.png")
             width, height = image.size
-            dwg = svgwrite.Drawing(f'{base_image_path}.svg', size=(f'{width}px', f'{height}px'), profile='full')
+            dwg = svgwrite.Drawing(
+                f"{base_image_path}.svg",
+                size=(f"{width}px", f"{height}px"),
+                profile="full",
+            )
             Inkscape(dwg)
-            img = dwg.add(svgwrite.image.Image(f'{base_image_path}.png', insert=(0, 0), size=(f'{width}px', f'{height}px')))
+            img = dwg.add(
+                svgwrite.image.Image(
+                    f"{base_image_path}.png",
+                    insert=(0, 0),
+                    size=(f"{width}px", f"{height}px"),
+                )
+            )
 
             # workaround: add missing locking attribute for image element
             # https://github.com/mozman/svgwrite/blob/c8cbf6f615910b3818ccf939fce0e407c9c789cb/svgwrite/extensions/inkscape.py#L50
             elements = dwg.validator.elements
-            elements['image'].valid_attributes = {'sodipodi:insensitive', } | elements['image'].valid_attributes
-            img.attribs['sodipodi:insensitive'] = 'true'
+            elements["image"].valid_attributes = {
+                "sodipodi:insensitive",
+            } | elements["image"].valid_attributes
+            img.attribs["sodipodi:insensitive"] = "true"
 
             dwg.save(pretty=True)
 
@@ -206,7 +257,9 @@ cli.add_command(paginate)
 # Register command docstrings for doctesting.
 # Since commands are not fnuctions anymore due to their decorator, their
 # docstrings would otherwise be ignored.
-__test__ = {name: command.__doc__ for (name, command) in cli.commands.items() if command.__doc__}
+__test__ = {
+    name: command.__doc__ for (name, command) in cli.commands.items() if command.__doc__
+}
 
 if __name__ == "__main__":
     cli()

--- a/svgdigitizer/electrochemistry/cv.py
+++ b/svgdigitizer/electrochemistry/cv.py
@@ -54,10 +54,10 @@ import matplotlib.pyplot as plt
 from astropy import units as u
 import logging
 
-logger = logging.getLogger('cv')
+logger = logging.getLogger("cv")
 
 
-class CV():
+class CV:
     r"""
     A digitized cyclic voltammogram (CV) derived from an SVG file,
     which provides access to the objects of the CV.
@@ -127,6 +127,7 @@ class CV():
         {'figure description': {'type': 'digitized', 'measurement type': 'CV', 'scan rate': {'value': 50.0, 'unit': 'V / s'}, 'potential scale': {'unit': 'mV', 'reference': 'RHE'}, 'current': {'unit': 'uA / cm2'}, 'comment': ''}}
 
     """
+
     def __init__(self, svgplot, metadata=None):
         self.svgplot = svgplot
         self._metadata = metadata or {}
@@ -205,10 +206,17 @@ class CV():
             {'x': {'dimension': 'U', 'unit': 'V'}, 'y': {'dimension': 'j', 'unit': 'A / m2'}}
 
         """
-        return {'x': {'dimension': 'U',
-                      'unit': 'V'},
-                'y': {'dimension': 'j' if 'm2' in str(CV.get_axis_unit(self.svgplot.axis_labels['y'])) else 'I',
-                      'unit': 'A / m2' if 'm2' in str(CV.get_axis_unit(self.svgplot.axis_labels['y'])) else 'A'}}
+        return {
+            "x": {"dimension": "U", "unit": "V"},
+            "y": {
+                "dimension": "j"
+                if "m2" in str(CV.get_axis_unit(self.svgplot.axis_labels["y"]))
+                else "I",
+                "unit": "A / m2"
+                if "m2" in str(CV.get_axis_unit(self.svgplot.axis_labels["y"]))
+                else "A",
+            },
+        }
 
     @classmethod
     def get_axis_unit(cls, unit):
@@ -225,23 +233,41 @@ class CV():
             Unit("uA / cm2")
 
         """
-        unit_typos = {'uA / cm2': ['uA / cm2', 'uA / cm²', 'µA / cm²', 'uA/cm2', 'uA/cm²', 'µA/cm²', 'µA cm⁻²', 'uA cm-2'],
-                      'mA / cm2': ['mA / cm2', 'mA / cm²', 'mA cm⁻²', 'mA/cm2', 'mA/cm²', 'mA cm-2'],
-                      'A / cm2': ['A / cm2', 'A/cm2', 'A cm⁻²', 'A cm-2'],
-                      'uA': ['uA', 'µA', 'microampere'],
-                      'mA': ['mA', 'milliampere'],
-                      'A': ['A', 'ampere', 'amps', 'amp'],
-                      'mV': ['milliV', 'millivolt', 'milivolt', 'miliv', 'mV'],
-                      'V': ['V', 'v', 'Volt', 'volt'],
-                      'V / s': ['V s-1', 'V/s', 'V / s'],
-                      'mV / s': ['mV / s', 'mV s-1', 'mV/s']}
+        unit_typos = {
+            "uA / cm2": [
+                "uA / cm2",
+                "uA / cm²",
+                "µA / cm²",
+                "uA/cm2",
+                "uA/cm²",
+                "µA/cm²",
+                "µA cm⁻²",
+                "uA cm-2",
+            ],
+            "mA / cm2": [
+                "mA / cm2",
+                "mA / cm²",
+                "mA cm⁻²",
+                "mA/cm2",
+                "mA/cm²",
+                "mA cm-2",
+            ],
+            "A / cm2": ["A / cm2", "A/cm2", "A cm⁻²", "A cm-2"],
+            "uA": ["uA", "µA", "microampere"],
+            "mA": ["mA", "milliampere"],
+            "A": ["A", "ampere", "amps", "amp"],
+            "mV": ["milliV", "millivolt", "milivolt", "miliv", "mV"],
+            "V": ["V", "v", "Volt", "volt"],
+            "V / s": ["V s-1", "V/s", "V / s"],
+            "mV / s": ["mV / s", "mV s-1", "mV/s"],
+        }
 
         for correct_unit, typos in unit_typos.items():
             for typo in typos:
                 if unit == typo:
                     return u.Unit(correct_unit)
 
-        raise ValueError(f'Unknown Unit {unit}')
+        raise ValueError(f"Unknown Unit {unit}")
 
     @property
     def x_label(self):
@@ -292,10 +318,12 @@ class CV():
             'RHE'
 
         """
-        pattern = r'^(?P<unit>.+?)? *(?:(?:@|vs\.?) *(?P<reference>.+))?$'
-        match = re.match(pattern, self.svgplot.axis_labels['x'], re.IGNORECASE)
+        pattern = r"^(?P<unit>.+?)? *(?:(?:@|vs\.?) *(?P<reference>.+))?$"
+        match = re.match(pattern, self.svgplot.axis_labels["x"], re.IGNORECASE)
 
-        return namedtuple('Label', ['label', 'unit', 'reference'])(match[0], match[1], match[2] or 'unknown')
+        return namedtuple("Label", ["label", "unit", "reference"])(
+            match[0], match[1], match[2] or "unknown"
+        )
 
     @property
     @cache
@@ -336,7 +364,9 @@ class CV():
             <Quantity 50. V / s>
 
         """
-        rates = self.svgplot.svg.get_texts('(?:scan rate|rate): (?P<value>-?[0-9.]+) *(?P<unit>.*)')
+        rates = self.svgplot.svg.get_texts(
+            "(?:scan rate|rate): (?P<value>-?[0-9.]+) *(?P<unit>.*)"
+        )
         # TODO: assert that only one label contains the scan rate (see issue #58)
         # TODO: assert that a rate is available at all (see issue #58)
 
@@ -421,7 +451,7 @@ class CV():
         self._add_time_axis(df)
 
         # Rearrange columns.
-        return df[['t', 'U', self.axis_properties['y']['dimension']]]
+        return df[["t", "U", self.axis_properties["y"]["dimension"]]]
 
     def _add_U_axis(self, df):
         r"""
@@ -464,7 +494,7 @@ class CV():
         q = 1 * CV.get_axis_unit(self.x_label.unit)
         # Convert the axis unit to SI unit V and use the value
         # to convert the potential values in the df to V
-        df['U'] = df['x'] * q.to(u.V).value
+        df["U"] = df["x"] * q.to(u.V).value
 
     def _add_I_axis(self, df):
         r"""
@@ -504,15 +534,15 @@ class CV():
             >>> cv._add_I_axis(df = cv.svgplot.df.copy())
 
         """
-        q = 1 * CV.get_axis_unit(self.svgplot.axis_labels['y'])
+        q = 1 * CV.get_axis_unit(self.svgplot.axis_labels["y"])
 
         # Distinguish whether the y data is current ('A') or current density ('A / cm2')
-        if 'm2' in str(q.unit):
-            conversion_factor = q.to(u.A / u.m**2)
+        if "m2" in str(q.unit):
+            conversion_factor = q.to(u.A / u.m ** 2)
         else:
             conversion_factor = q.to(u.A)
 
-        df[self.axis_properties['y']['dimension']] = df['y'] * conversion_factor
+        df[self.axis_properties["y"]["dimension"]] = df["y"] * conversion_factor
 
     def _add_time_axis(self, df):
         r"""
@@ -554,9 +584,9 @@ class CV():
             >>> cv._add_time_axis(df)
 
         """
-        df['deltaU'] = abs(df['U'].diff().fillna(0))
-        df['cumdeltaU'] = df['deltaU'].cumsum()
-        df['t'] = df['cumdeltaU'] / float(self.rate.to(u.V / u.s).value)
+        df["deltaU"] = abs(df["U"].diff().fillna(0))
+        df["cumdeltaU"] = df["deltaU"].cumsum()
+        df["t"] = df["cumdeltaU"] / float(self.rate.to(u.V / u.s).value)
 
     def plot(self):
         r"""
@@ -596,10 +626,25 @@ class CV():
             >>> cv.plot()
 
         """
-        self.df.plot(x=self.axis_properties['x']['dimension'], y=self.axis_properties['y']['dimension'])
-        plt.axhline(linewidth=1, linestyle=':', alpha=0.5)
-        plt.xlabel(self.axis_properties['x']['dimension'] + ' [' + str(self.axis_properties['x']['unit']) + ' vs. ' + self.x_label.reference + ']')
-        plt.ylabel(self.axis_properties['y']['dimension'] + ' [' + str(self.axis_properties['y']['unit']) + ']')
+        self.df.plot(
+            x=self.axis_properties["x"]["dimension"],
+            y=self.axis_properties["y"]["dimension"],
+        )
+        plt.axhline(linewidth=1, linestyle=":", alpha=0.5)
+        plt.xlabel(
+            self.axis_properties["x"]["dimension"]
+            + " ["
+            + str(self.axis_properties["x"]["unit"])
+            + " vs. "
+            + self.x_label.reference
+            + "]"
+        )
+        plt.ylabel(
+            self.axis_properties["y"]["dimension"]
+            + " ["
+            + str(self.axis_properties["y"]["unit"])
+            + "]"
+        )
 
     @property
     @cache
@@ -671,11 +716,13 @@ class CV():
             ''
 
         """
-        comments = self.svgplot.svg.get_texts('(?:comment): (?P<value>.*)')
+        comments = self.svgplot.svg.get_texts("(?:comment): (?P<value>.*)")
         if not comments:
-            return ''
+            return ""
         elif len(comments) > 1:
-            logger.warning(f"More than one comment. Ignoring all comments except for the first: {comments[0]}.")
+            logger.warning(
+                f"More than one comment. Ignoring all comments except for the first: {comments[0]}."
+            )
         return comments[0].value
 
     @property
@@ -720,14 +767,23 @@ class CV():
 
         """
         metadata = self._metadata.copy()
-        metadata.setdefault('figure description', {})
-        metadata['figure description']['type'] = 'digitized'
-        metadata['figure description']['measurement type'] = 'CV'
-        metadata['figure description']['scan rate'] = {'value': float(self.rate.value), 'unit': str(self.rate.unit)}
-        metadata['figure description'].setdefault('potential scale', {})
-        metadata['figure description']['potential scale']['unit'] = str(CV.get_axis_unit(self.x_label.unit))
-        metadata['figure description']['potential scale']['reference'] = self.x_label.reference
-        metadata['figure description']['current'] = {'unit': str(CV.get_axis_unit(self.svgplot.axis_labels['y']))}
-        metadata['figure description']['comment'] = self.comment
+        metadata.setdefault("figure description", {})
+        metadata["figure description"]["type"] = "digitized"
+        metadata["figure description"]["measurement type"] = "CV"
+        metadata["figure description"]["scan rate"] = {
+            "value": float(self.rate.value),
+            "unit": str(self.rate.unit),
+        }
+        metadata["figure description"].setdefault("potential scale", {})
+        metadata["figure description"]["potential scale"]["unit"] = str(
+            CV.get_axis_unit(self.x_label.unit)
+        )
+        metadata["figure description"]["potential scale"][
+            "reference"
+        ] = self.x_label.reference
+        metadata["figure description"]["current"] = {
+            "unit": str(CV.get_axis_unit(self.svgplot.axis_labels["y"]))
+        }
+        metadata["figure description"]["comment"] = self.comment
 
         return metadata

--- a/svgdigitizer/electrochemistry/cv.py
+++ b/svgdigitizer/electrochemistry/cv.py
@@ -47,12 +47,13 @@ For the documentation below, the path of a CV is presented simply as line.
 #  You should have received a copy of the GNU General Public License
 #  along with svgdigitizer. If not, see <https://www.gnu.org/licenses/>.
 # ********************************************************************
+import logging
+import re
 from collections import namedtuple
 from functools import cache
-import re
+
 import matplotlib.pyplot as plt
 from astropy import units as u
-import logging
 
 logger = logging.getLogger("cv")
 

--- a/svgdigitizer/svg.py
+++ b/svgdigitizer/svg.py
@@ -23,7 +23,7 @@ from xml.dom import minidom, Node
 import re
 import logging
 
-logger = logging.getLogger('svg')
+logger = logging.getLogger("svg")
 
 
 class SVG:
@@ -55,6 +55,7 @@ class SVG:
         SVG('<?xml version="1.0" ?><svg>\n    <!-- an empty SVG -->\n</svg>')
 
     """
+
     def __init__(self, svg):
         if isinstance(svg, str):
             self.svg = minidom.parseString(svg)
@@ -101,11 +102,13 @@ class SVG:
         """
         labeled_paths = []
 
-        groups = set(path.parentNode for path in self.svg.getElementsByTagName('path'))
+        groups = set(path.parentNode for path in self.svg.getElementsByTagName("path"))
 
         for group in groups:
-            if group.nodeType != Node.ELEMENT_NODE or group.tagName != 'g':
-                logger.warning("Parent of <path> is not a <g>. Ignoring this path and its siblings.")
+            if group.nodeType != Node.ELEMENT_NODE or group.tagName != "g":
+                logger.warning(
+                    "Parent of <path> is not a <g>. Ignoring this path and its siblings."
+                )
                 continue
 
             # Determine the label associated to these <path>s
@@ -115,16 +118,22 @@ class SVG:
                     continue
                 elif child.nodeType == Node.TEXT_NODE:
                     if SVG._text_value(child):
-                        logger.warning(f'Ignoring unexpected text node "{SVG._text_value(child)}" grouped with <path>.')
+                        logger.warning(
+                            f'Ignoring unexpected text node "{SVG._text_value(child)}" grouped with <path>.'
+                        )
                 elif child.nodeType == Node.ELEMENT_NODE:
-                    if child.tagName == 'path':
+                    if child.tagName == "path":
                         continue
                     if child.tagName != "text":
-                        logger.warning(f"Unexpected <{child.tagName}> grouped with <path>. Ignoring unexpected <{child.tagName}>.")
+                        logger.warning(
+                            f"Unexpected <{child.tagName}> grouped with <path>. Ignoring unexpected <{child.tagName}>."
+                        )
                         continue
 
                     if label is not None:
-                        logger.warning(f'More than one <text> label associated to this <path>. Ignoring all but the first one, i.e., ignoring "{SVG._text_value(child)}".')
+                        logger.warning(
+                            f'More than one <text> label associated to this <path>. Ignoring all but the first one, i.e., ignoring "{SVG._text_value(child)}".'
+                        )
                         continue
 
                     label = child
@@ -134,7 +143,11 @@ class SVG:
                 continue
 
             # Determine all the <path>s in this <g>.
-            paths = [path for path in group.childNodes if path.nodeType == Node.ELEMENT_NODE and path.tagName == 'path']
+            paths = [
+                path
+                for path in group.childNodes
+                if path.nodeType == Node.ELEMENT_NODE and path.tagName == "path"
+            ]
             assert paths
 
             # Parse the label
@@ -203,7 +216,9 @@ class SVG:
         if element is None or element.nodeType == Node.DOCUMENT_NODE:
             return parse_transform(None)
 
-        return cls._get_transform(element.parentNode).dot(parse_transform(element.getAttribute('transform')))
+        return cls._get_transform(element.parentNode).dot(
+            parse_transform(element.getAttribute("transform"))
+        )
 
     @classmethod
     def transform(cls, element):
@@ -239,22 +254,23 @@ class SVG:
         """
         transformation = cls._get_transform(element)
 
-        if element.getAttribute('d'):
+        if element.getAttribute("d"):
             # element is like a path
             from svgpathtools.path import transform
             from svgpathtools.parser import parse_path
-            element = transform(parse_path(element.getAttribute('d')), transformation)
-        elif element.hasAttribute('x') and element.hasAttribute('y'):
+
+            element = transform(parse_path(element.getAttribute("d")), transformation)
+        elif element.hasAttribute("x") and element.hasAttribute("y"):
             # elements with an explicit location such as <text>
-            x = float(element.getAttribute('x'))
-            y = float(element.getAttribute('y'))
+            x = float(element.getAttribute("x"))
+            y = float(element.getAttribute("y"))
             x, y, _ = transformation.dot([x, y, 1])
 
             element = element.cloneNode(deep=True)
-            if element.hasAttribute('transform'):
-                element.removeAttribute('transform')
-            element.setAttribute('x', str(x))
-            element.setAttribute('y', str(y))
+            if element.hasAttribute("transform"):
+                element.removeAttribute("transform")
+            element.setAttribute("x", str(x))
+            element.setAttribute("y", str(y))
         else:
             raise NotImplementedError(f"Unsupported element {element}.")
 
@@ -303,6 +319,7 @@ class LabeledPaths:
         [[Path "curve: 0"]]
 
     """
+
     def __init__(self, label, paths, match):
         if not paths:
             raise ValueError("LabeledPaths must consist of at least one path.")
@@ -364,13 +381,14 @@ class Text:
         100.0
 
     """
+
     def __init__(self, label, match):
         self._label = label
         self._value = SVG._text_value(label)
 
         transformed = SVG.transform(label)
-        self.x = float(transformed.getAttribute('x'))
-        self.y = float(transformed.getAttribute('y'))
+        self.x = float(transformed.getAttribute("x"))
+        self.y = float(transformed.getAttribute("y"))
 
         for key, value in match.groupdict().items():
             setattr(self, key, value)
@@ -400,6 +418,7 @@ class LabeledPath:
         Path "curve: 0"
 
     """
+
     def __init__(self, path, label):
         self._path = path
         self._label = label
@@ -426,7 +445,9 @@ class LabeledPath:
         """
         text = self._label.x, self._label.y
         endpoints = [self.points[0], self.points[-1]]
-        return max(endpoints, key=lambda p: (text[0] - p[0]) ** 2 + (text[1] - p[1]) ** 2)
+        return max(
+            endpoints, key=lambda p: (text[0] - p[0]) ** 2 + (text[1] - p[1]) ** 2
+        )
 
     @classmethod
     def path_points(cls, path):
@@ -438,7 +459,9 @@ class LabeledPath:
         points are connected by `M` commands that do not actually draw
         anything, or any kind of visible curve.
         """
-        return [(path[0].start.real, path[0].start.imag)] + [(command.end.real, command.end.imag) for command in path]
+        return [(path[0].start.real, path[0].start.imag)] + [
+            (command.end.real, command.end.imag) for command in path
+        ]
 
     @property
     def points(self):
@@ -503,6 +526,7 @@ class LabeledPath:
 
         """
         from svgpathtools import Path
+
         return SVG.transform(self._path)
 
     def __repr__(self):

--- a/svgdigitizer/svg.py
+++ b/svgdigitizer/svg.py
@@ -19,9 +19,9 @@
 #  You should have received a copy of the GNU General Public License
 #  along with svgdigitizer. If not, see <https://www.gnu.org/licenses/>.
 # ********************************************************************
-from xml.dom import minidom, Node
-import re
 import logging
+import re
+from xml.dom import Node, minidom
 
 logger = logging.getLogger("svg")
 
@@ -256,8 +256,8 @@ class SVG:
 
         if element.getAttribute("d"):
             # element is like a path
-            from svgpathtools.path import transform
             from svgpathtools.parser import parse_path
+            from svgpathtools.path import transform
 
             element = transform(parse_path(element.getAttribute("d")), transformation)
         elif element.hasAttribute("x") and element.hasAttribute("y"):

--- a/svgdigitizer/svgplot.py
+++ b/svgdigitizer/svgplot.py
@@ -25,7 +25,7 @@ import pandas as pd
 from functools import cache
 import logging
 
-logger = logging.getLogger('svgplot')
+logger = logging.getLogger("svgplot")
 
 
 class SVGPlot:
@@ -88,10 +88,19 @@ class SVGPlot:
         1  1.0  1.0
 
     """
-    def __init__(self, svg, xlabel=None, ylabel=None, sampling_interval=None, curve=None, algorithm='axis-aligned'):
+
+    def __init__(
+        self,
+        svg,
+        xlabel=None,
+        ylabel=None,
+        sampling_interval=None,
+        curve=None,
+        algorithm="axis-aligned",
+    ):
         self.svg = svg
-        self.xlabel = xlabel or 'x'
-        self.ylabel = ylabel or 'y'
+        self.xlabel = xlabel or "x"
+        self.ylabel = ylabel or "y"
         self.sampling_interval = sampling_interval
         self._curve = curve
         self._algorithm = algorithm
@@ -194,9 +203,14 @@ class SVGPlot:
             ['WARNING:svgplot:Labels on y axis do not match. Will ignore label mA and use A.']
 
         """
+
         def axis_label(axis):
             labels = [
-                point[1][-1] for point in [self.marked_points[axis + "1"], self.marked_points[axis + "2"]]
+                point[1][-1]
+                for point in [
+                    self.marked_points[axis + "1"],
+                    self.marked_points[axis + "2"],
+                ]
                 if point[1][-1] is not None
             ]
 
@@ -204,7 +218,9 @@ class SVGPlot:
                 return None
             if len(labels) == 2:
                 if labels[0] != labels[1]:
-                    logger.warning(f"Labels on {axis} axis do not match. Will ignore label {labels[0]} and use {labels[1]}.")
+                    logger.warning(
+                        f"Labels on {axis} axis do not match. Will ignore label {labels[0]} and use {labels[1]}."
+                    )
             return labels[-1]
 
         return {
@@ -290,7 +306,7 @@ class SVGPlot:
         ylabels = [f"{self.ylabel}1", f"{self.ylabel}2"]
 
         # Process explicitly marked point on the axes.
-        for labeled_paths in self.labeled_paths['ref_point']:
+        for labeled_paths in self.labeled_paths["ref_point"]:
             label = labeled_paths.label.point
             value = float(labeled_paths.label.value)
             unit = labeled_paths.label.unit or None
@@ -300,13 +316,17 @@ class SVGPlot:
             elif label in ylabels:
                 plot = (None, value, unit)
             else:
-                raise NotImplementedError(f"Unexpected label grouped with marked point. Expected the label to be one of {xlabels + ylabels} but found {label}.")
+                raise NotImplementedError(
+                    f"Unexpected label grouped with marked point. Expected the label to be one of {xlabels + ylabels} but found {label}."
+                )
 
             if label in points:
                 raise Exception(f"Found axis label {label} more than once.")
 
             if len(labeled_paths.paths) != 1:
-                raise NotImplementedError(f"Expected exactly one path to be grouped with the marked point {label} but found {len(labeled_paths.paths)}.")
+                raise NotImplementedError(
+                    f"Expected exactly one path to be grouped with the marked point {label} but found {len(labeled_paths.paths)}."
+                )
 
             path = labeled_paths.paths[0]
 
@@ -318,29 +338,43 @@ class SVGPlot:
             raise Exception(f"Label {ylabels[0]} not found in SVG.")
 
         # Process scale bars.
-        for labeled_paths in self.labeled_paths['scale_bar']:
+        for labeled_paths in self.labeled_paths["scale_bar"]:
             label = labeled_paths.label.axis
             value = float(labeled_paths.label.value)
             unit = labeled_paths.label.unit or None
 
             if label not in [self.xlabel, self.ylabel]:
-                raise Exception(f"Expected label on scalebar to be one of {self.xlabel}, {self.ylabel} but found {label}.")
+                raise Exception(
+                    f"Expected label on scalebar to be one of {self.xlabel}, {self.ylabel} but found {label}."
+                )
 
             if label + "2" in points:
-                raise Exception(f"Found more than one axis label {label}2 and scalebar for {label}.")
+                raise Exception(
+                    f"Found more than one axis label {label}2 and scalebar for {label}."
+                )
 
             if len(labeled_paths.paths) != 2:
-                raise NotImplementedError(f"Expected exactly two paths to be grouped with the scalebar label {label} but found {len(labeled_paths.paths)}.")
+                raise NotImplementedError(
+                    f"Expected exactly two paths to be grouped with the scalebar label {label} but found {len(labeled_paths.paths)}."
+                )
 
             endpoints = [path.far for path in labeled_paths.paths]
-            scalebar = (endpoints[0][0] - endpoints[1][0], endpoints[0][1] - endpoints[1][1])
+            scalebar = (
+                endpoints[0][0] - endpoints[1][0],
+                endpoints[0][1] - endpoints[1][1],
+            )
 
             # The scalebar has an explicit orientation in the SVG but the
             # author of the scalebar was likely not aware.
             # We assume here that the scalebar was meant to be oriented like
             # the coordinate system in the SVG, i.e., x coordinates grow to the
             # right, y coordinates grow to the bottom.
-            if label == self.xlabel and scalebar[0] < 0 or label == self.ylabel and scalebar[1] > 0:
+            if (
+                label == self.xlabel
+                and scalebar[0] < 0
+                or label == self.ylabel
+                and scalebar[1] > 0
+            ):
                 scalebar = (-scalebar[0], -scalebar[1])
 
             # Construct the second marked point from the first marked point + scalebar.
@@ -383,7 +417,9 @@ class SVGPlot:
         """
         scaling_factors = {self.xlabel: 1, self.ylabel: 1}
 
-        for label in self.svg.get_texts(r'^(?P<axis>x|y)(_scaling_factor|sf)\: (?P<value>-?\d+\.?\d*)'):
+        for label in self.svg.get_texts(
+            r"^(?P<axis>x|y)(_scaling_factor|sf)\: (?P<value>-?\d+\.?\d*)"
+        ):
             scaling_factors[label.axis] = float(label.value)
 
         return scaling_factors
@@ -497,6 +533,7 @@ class SVGPlot:
 
         """
         from numpy import dot
+
         return tuple(dot(self.transformation, [x, y, 1])[:2])
 
     @property
@@ -642,24 +679,29 @@ class SVGPlot:
             ([0, 0, 0, y2[0][0], y2[0][1], 1], y2[1][1]),
         ]
 
-        if self._algorithm == 'axis-aligned':
-            conditions.extend([
-                # Moving along the SVG x axis does not change the y coordinate
-                ([0, 0, 0, 1, 0, 0], 0),
-                # Moving along the SVG y axis does not change the x coordinate
-                ([0, 1, 0, 0, 0, 0], 0),
-            ])
-        elif self._algorithm == 'mark-aligned':
-            conditions.extend([
-                # x1 and x2 map to the same y coordinate
-                ([0, 0, 0, x1[0][0] - x2[0][0], x1[0][1] - x2[0][1], 0], 0),
-                # y1 and y2 map to the same x coordinate
-                ([y1[0][0] - y2[0][0], y1[0][1] - y2[0][1], 0, 0, 0, 0], 0),
-            ])
+        if self._algorithm == "axis-aligned":
+            conditions.extend(
+                [
+                    # Moving along the SVG x axis does not change the y coordinate
+                    ([0, 0, 0, 1, 0, 0], 0),
+                    # Moving along the SVG y axis does not change the x coordinate
+                    ([0, 1, 0, 0, 0, 0], 0),
+                ]
+            )
+        elif self._algorithm == "mark-aligned":
+            conditions.extend(
+                [
+                    # x1 and x2 map to the same y coordinate
+                    ([0, 0, 0, x1[0][0] - x2[0][0], x1[0][1] - x2[0][1], 0], 0),
+                    # y1 and y2 map to the same x coordinate
+                    ([y1[0][0] - y2[0][0], y1[0][1] - y2[0][1], 0, 0, 0, 0], 0),
+                ]
+            )
         else:
             raise NotImplementedError(f"Unknown algorithm {self._algorithm}.")
 
         from numpy.linalg import solve
+
         A = solve([c[0] for c in conditions], [c[1] for c in conditions])
 
         # Rewrite the solution as a linear transformation matrix.
@@ -671,11 +713,15 @@ class SVGPlot:
 
         # Apply scaling factors, as a diagonal matrix.
         from numpy import dot
-        A = dot([
-            [1/self.scaling_factors[self.xlabel], 0, 0],
-            [0, 1/self.scaling_factors[self.ylabel], 0],
-            [0, 0, 1],
-        ], A)
+
+        A = dot(
+            [
+                [1 / self.scaling_factors[self.xlabel], 0, 0],
+                [0, 1 / self.scaling_factors[self.ylabel], 0],
+                [0, 0, 1],
+            ],
+            A,
+        )
 
         return A
 
@@ -733,7 +779,11 @@ class SVGPlot:
             Exception: No curve main curve found in SVG.
 
         """
-        curves = [curve for curve in self.labeled_paths['curve'] if self._curve is None or curve.label.curve_id == self._curve]
+        curves = [
+            curve
+            for curve in self.labeled_paths["curve"]
+            if self._curve is None or curve.label.curve_id == self._curve
+        ]
 
         if len(curves) == 0:
             raise Exception(f"No curve {self._curve} found in SVG.")
@@ -750,6 +800,7 @@ class SVGPlot:
         path = paths[0]
 
         from svgpathtools.path import transform
+
         return transform(path.path, self.transformation)
 
     @property
@@ -764,15 +815,20 @@ class SVGPlot:
         are going to extract the (x, y) coordinate pairs from.
         """
         patterns = {
-            'ref_point': r'^(?P<point>(x|y)\d)\: ?(?P<value>-?\d+\.?\d*) *(?P<unit>.+)?',
-            'scale_bar': r'^(?P<axis>x|y)(_scale_bar|sb)\: ?(?P<value>-?\d+\.?\d*) *(?P<unit>.+)?',
-            'curve': r'^curve: ?(?P<curve_id>.+)',
+            "ref_point": r"^(?P<point>(x|y)\d)\: ?(?P<value>-?\d+\.?\d*) *(?P<unit>.+)?",
+            "scale_bar": r"^(?P<axis>x|y)(_scale_bar|sb)\: ?(?P<value>-?\d+\.?\d*) *(?P<unit>.+)?",
+            "curve": r"^curve: ?(?P<curve_id>.+)",
         }
 
-        labeled_paths = {key: self.svg.get_labeled_paths(pattern) for (key, pattern) in patterns.items()}
+        labeled_paths = {
+            key: self.svg.get_labeled_paths(pattern)
+            for (key, pattern) in patterns.items()
+        }
 
         for paths in self.svg.get_labeled_paths():
-            if paths.label._label not in [p.label._label for pattern in patterns for p in labeled_paths[pattern]]:
+            if paths.label._label not in [
+                p.label._label for pattern in patterns for p in labeled_paths[pattern]
+            ]:
                 logger.warning(f"Ignoring <path> with unsupported label {paths.label}.")
 
         return labeled_paths
@@ -876,18 +932,26 @@ class SVGPlot:
         for segment in path:
             sample_at = []
 
-            if endpoints == 'include':
+            if endpoints == "include":
                 # Include the initial point of the new path segment.
                 sample_at.append(0)
 
                 # Continue sampling from the start of the new path segment.
-                assert sampling_interval >= X, "sampling with endpoints should produce more points than sampling without"
+                assert (
+                    sampling_interval >= X
+                ), "sampling with endpoints should produce more points than sampling without"
                 X = sampling_interval
 
             x = numpy.poly1d(numpy.real(segment.poly()))
 
             # At the extrema of the projection to the x-axis, the curve changes direction.
-            extrema = list(sorted(root.real for root in numpy.polyder(x).roots if abs(root.imag) < EPS and 0 < root.real < 1))
+            extrema = list(
+                sorted(
+                    root.real
+                    for root in numpy.polyder(x).roots
+                    if abs(root.imag) < EPS and 0 < root.real < 1
+                )
+            )
 
             # Eventually this will contain the total length of this path segment.
             segment_length = 0
@@ -920,11 +984,17 @@ class SVGPlot:
                     # values for X at once which might be much faster:
                     # https://en.wikipedia.org/wiki/Cubic_equation#General_cubic_formula
                     roots = (f - X).roots
-                    assert len(roots), f"The polynomial {f} should not be constant and therefore should have some roots."
+                    assert len(
+                        roots
+                    ), f"The polynomial {f} should not be constant and therefore should have some roots."
                     real_roots = roots.real[abs(roots.imag) < EPS]
-                    assert len(real_roots), f"The polynomial {f} should have a real root in [{tmin}, {tmax}] but we only found complex roots {roots}"
+                    assert len(
+                        real_roots
+                    ), f"The polynomial {f} should have a real root in [{tmin}, {tmax}] but we only found complex roots {roots}"
                     eligible_roots = [t for t in real_roots if tmin <= t <= tmax]
-                    assert eligible_roots, f"The polynomial {f} should have a real root in [{tmin}, {tmax}] but all roots were outside that range: {roots}"
+                    assert (
+                        eligible_roots
+                    ), f"The polynomial {f} should have a real root in [{tmin}, {tmax}] but all roots were outside that range: {roots}"
                     t = min(eligible_roots)
 
                     sample_at.append(t)
@@ -932,15 +1002,19 @@ class SVGPlot:
                     X += sampling_interval
 
             # We have left the current path segment.
-            if endpoints == 'include':
+            if endpoints == "include":
                 # Include the final point of this path segment.
                 sample_at.append(1)
 
-            assert sample_at == sorted(sample_at), f"Samples are out of order {sample_at}"
+            assert sample_at == sorted(
+                sample_at
+            ), f"Samples are out of order {sample_at}"
 
-            if endpoints == 'include':
+            if endpoints == "include":
                 # Do not sample points that are just a numerical-error away from the end points.
-                assert sample_at[1] > EPS, f"First real sampling point should be quite a bit away from t=0 but it is only at {sample_at[1]}"
+                assert (
+                    sample_at[1] > EPS
+                ), f"First real sampling point should be quite a bit away from t=0 but it is only at {sample_at[1]}"
                 if 1 - sample_at[-2] < EPS:
                     sample_at = sample_at[:-2] + [sample_at[-1]]
 
@@ -1069,6 +1143,7 @@ class SVGPlot:
             points = SVGPlot.sample_path(self.curve, self.sampling_interval)
         else:
             from .svg import LabeledPath
+
             points = LabeledPath.path_points(self.curve)
 
         return pd.DataFrame(points, columns=[self.xlabel, self.ylabel])
@@ -1108,4 +1183,10 @@ class SVGPlot:
             >>> plot.plot()
 
         """
-        self.df.plot(x=self.xlabel, y=self.ylabel, xlabel=f"{self.xlabel} [{self.axis_labels[self.xlabel]}]", ylabel=f"{self.ylabel} [{self.axis_labels[self.ylabel]}]", legend=False)
+        self.df.plot(
+            x=self.xlabel,
+            y=self.ylabel,
+            xlabel=f"{self.xlabel} [{self.axis_labels[self.xlabel]}]",
+            ylabel=f"{self.ylabel} [{self.axis_labels[self.ylabel]}]",
+            legend=False,
+        )

--- a/svgdigitizer/svgplot.py
+++ b/svgdigitizer/svgplot.py
@@ -19,11 +19,12 @@
 #  You should have received a copy of the GNU General Public License
 #  along with svgdigitizer. If not, see <https://www.gnu.org/licenses/>.
 # ********************************************************************
+import logging
+from functools import cache
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from functools import cache
-import logging
 
 logger = logging.getLogger("svgplot")
 

--- a/svgdigitizer/test/cli.py
+++ b/svgdigitizer/test/cli.py
@@ -74,10 +74,11 @@ class TemporaryData:
         self._tmpdir = tempfile.TemporaryDirectory()
 
         try:
+            import glob
             import os
             import os.path
-            import glob
             import shutil
+
             import svgdigitizer
 
             cwd = os.getcwd()

--- a/svgdigitizer/test/cli.py
+++ b/svgdigitizer/test/cli.py
@@ -45,6 +45,7 @@ def invoke(command, *args):
 
     """
     from click.testing import CliRunner
+
     invocation = CliRunner().invoke(command, args, catch_exceptions=False)
     output = invocation.output.strip()
     if output:
@@ -63,11 +64,13 @@ class TemporaryData:
         True
 
     """
+
     def __init__(self, *patterns):
         self._patterns = patterns
 
     def __enter__(self):
         import tempfile
+
         self._tmpdir = tempfile.TemporaryDirectory()
 
         try:


### PR DESCRIPTION
part of #83.

While a proper linter is running in CI, it is not really complaining about anything yet as there are too many lint errors in our code currently. Let me fix these in a separate PR.

Code style is now enforced with black and isort. This combination is much more strict than pycodestyle. However, you can just run `black svgdigitizer` and `isort svgdigitizer` locally before pushing to GitHub to apply all the code changes that these deem necessary.