### PR TITLE
remove typo handling in get_axis_unit

### DIFF
--- a/svgdigitizer/electrochemistry/cv.py
+++ b/svgdigitizer/electrochemistry/cv.py
@@ -251,12 +251,11 @@ class CV:
             >>> unit = 'uA cm⁻²'
             >>> CV.get_axis_unit(unit)
             Unit("uA / cm2")
-            
-            >>> unit = 'milliV'
-            >>> CV.get_axis_unit(unit) # doctest: +IGNORE_EXCEPTION_DETAIL
-            ValueError: Astropy was not able to convert the given string ('milliV') into a meaningful astropy unit. Please review the unit string.
 
         """
+        #    >>> unit = 'milliV'
+        #    >>> CV.get_axis_unit(unit) # doctest: +IGNORE_EXCEPTION_DETAIL
+        #    ValueError: Astropy was not able to convert the given string (milliV) into a meaningful astropy unit. Please review the unit string.
         try:
             return u.Unit(unit)
         except ValueError as err:

--- a/svgdigitizer/electrochemistry/cv.py
+++ b/svgdigitizer/electrochemistry/cv.py
@@ -254,7 +254,7 @@ class CV:
 
         """
 
-        return u.Unit(u)
+        return u.Unit(unit)
 
     @property
     def x_label(self):

--- a/svgdigitizer/electrochemistry/cv.py
+++ b/svgdigitizer/electrochemistry/cv.py
@@ -252,6 +252,7 @@ class CV:
             >>> CV.get_axis_unit(unit)
             Unit("uA / cm2")
 
+        """
 
         return u.Unit(u)
 

--- a/svgdigitizer/electrochemistry/cv.py
+++ b/svgdigitizer/electrochemistry/cv.py
@@ -252,10 +252,13 @@ class CV:
             >>> CV.get_axis_unit(unit)
             Unit("uA / cm2")
 
+
+        >>> unit = 'milliV'
+        >>> CV.get_axis_unit(unit) # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+        ...
+        ValueError: Astropy was not able to convert the given string (milliV) into a meaningful astropy unit. Please review the unit string.
         """
-        #    >>> unit = 'milliV'
-        #    >>> CV.get_axis_unit(unit) # doctest: +IGNORE_EXCEPTION_DETAIL
-        #    ValueError: Astropy was not able to convert the given string (milliV) into a meaningful astropy unit. Please review the unit string.
         try:
             return u.Unit(unit)
         except ValueError as err:

--- a/svgdigitizer/electrochemistry/cv.py
+++ b/svgdigitizer/electrochemistry/cv.py
@@ -255,8 +255,10 @@ class CV:
         """
         try:
             return u.Unit(unit)
-        except ValueError as e:
-            raise ValueError(f"Astropy was not able to convert the given string ({unit}) to a meaningful unit. Please review the unit string.")
+        except ValueError as err:
+            raise ValueError(
+                f"Astropy was not able to convert the given string ({unit}) into a meaningful astropy unit. Please review the unit string."
+            ) from err
 
     @property
     def x_label(self):

--- a/svgdigitizer/electrochemistry/cv.py
+++ b/svgdigitizer/electrochemistry/cv.py
@@ -259,12 +259,7 @@ class CV:
         ...
         ValueError: Astropy was not able to convert the given string (milliV) into a meaningful astropy unit. Please review the unit string.
         """
-        try:
-            return u.Unit(unit)
-        except ValueError as err:
-            raise ValueError(
-                f"Astropy was not able to convert the given string ({unit}) into a meaningful astropy unit. Please review the unit string."
-            ) from err
+        return u.Unit(u)
 
     @property
     def x_label(self):

--- a/svgdigitizer/electrochemistry/cv.py
+++ b/svgdigitizer/electrochemistry/cv.py
@@ -251,6 +251,10 @@ class CV:
             >>> unit = 'uA cm⁻²'
             >>> CV.get_axis_unit(unit)
             Unit("uA / cm2")
+            
+            >>> unit = 'milliV'
+            >>> CV.get_axis_unit(unit) # doctest: +IGNORE_EXCEPTION_DETAIL
+            ValueError: Astropy was not able to convert the given string ('milliV') into a meaningful astropy unit. Please review the unit string.
 
         """
         try:

--- a/svgdigitizer/electrochemistry/cv.py
+++ b/svgdigitizer/electrochemistry/cv.py
@@ -248,42 +248,15 @@ class CV:
             >>> CV.get_axis_unit(unit)
             Unit("uA / cm2")
 
+            >>> unit = 'uA cm⁻²'
+            >>> CV.get_axis_unit(unit)
+            Unit("uA / cm2")
+
         """
-        unit_typos = {
-            "uA / cm2": [
-                "uA / cm2",
-                "uA / cm²",
-                "µA / cm²",
-                "uA/cm2",
-                "uA/cm²",
-                "µA/cm²",
-                "µA cm⁻²",
-                "uA cm-2",
-            ],
-            "mA / cm2": [
-                "mA / cm2",
-                "mA / cm²",
-                "mA cm⁻²",
-                "mA/cm2",
-                "mA/cm²",
-                "mA cm-2",
-            ],
-            "A / cm2": ["A / cm2", "A/cm2", "A cm⁻²", "A cm-2"],
-            "uA": ["uA", "µA", "microampere"],
-            "mA": ["mA", "milliampere"],
-            "A": ["A", "ampere", "amps", "amp"],
-            "mV": ["milliV", "millivolt", "milivolt", "miliv", "mV"],
-            "V": ["V", "v", "Volt", "volt"],
-            "V / s": ["V s-1", "V/s", "V / s"],
-            "mV / s": ["mV / s", "mV s-1", "mV/s"],
-        }
-
-        for correct_unit, typos in unit_typos.items():
-            for typo in typos:
-                if unit == typo:
-                    return u.Unit(correct_unit)
-
-        raise ValueError(f"Unknown Unit {unit}")
+        try:
+            return u.Unit(unit)
+        except ValueError as e:
+            raise ValueError(f"Astropy was not able to convert the given string ({unit}) to a meaningful unit. Please review the unit string.")
 
     @property
     def x_label(self):

--- a/svgdigitizer/electrochemistry/cv.py
+++ b/svgdigitizer/electrochemistry/cv.py
@@ -253,12 +253,6 @@ class CV:
             Unit("uA / cm2")
 
 
-        >>> unit = 'milliV'
-        >>> CV.get_axis_unit(unit) # doctest: +IGNORE_EXCEPTION_DETAIL
-        Traceback (most recent call last):
-        ...
-        ValueError: Astropy was not able to convert the given string (milliV) into a meaningful astropy unit. Please review the unit string.
-        """
         return u.Unit(u)
 
     @property


### PR DESCRIPTION
As astropy 5 can handle most of the typos which are included in the typos list we can omit the typos part in `get_axis_unit` and just print a nice message when astropy fails to convert the given string.

