### PR TITLE
Apply scaling factor for dimensions other than `x` and `y`

### DIFF
--- a/doc/news/scaling_factor.rst
+++ b/doc/news/scaling_factor.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed `svgplot.scaling_factors` such that scaling factors are now determined for any kind of axis dimension (so far only for axis labeled `x` or `y`).

--- a/svgdigitizer/svgplot.py
+++ b/svgdigitizer/svgplot.py
@@ -798,13 +798,41 @@ class SVGPlot:
             >>> plot.scaling_factors
             {'x': 50.6, 'y': 50.6}
 
+            >>> from svgdigitizer.svg import SVG
+            >>> from io import StringIO
+            >>> svg = SVG(StringIO(r'''
+            ... <svg>
+            ...   <text x="0" y="0">j_scaling_factor: 24.5</text>
+            ...   <text x="0" y="0">Esf: 18.3</text>
+            ...   <g>
+            ...     <path d="M 0 200 L 0 100" />
+            ...     <text x="0" y="200">E1: 0</text>
+            ...   </g>
+            ...   <g>
+            ...     <path d="M 100 200 L 100 100" />
+            ...     <text x="100" y="200">E2: 1</text>
+            ...   </g>
+            ...   <g>
+            ...     <path d="M -100 100 L 0 100" />
+            ...     <text x="-100" y="100">j1: 0</text>
+            ...   </g>
+            ...   <g>
+            ...     <path d="M -100 0 L 0 0" />
+            ...     <text x="-100" y="0">j2: 1</text>
+            ...   </g>
+            ... </svg>'''))
+            >>> plot = SVGPlot(svg)
+            >>> plot.scaling_factors
+            {'E': 18.3, 'j': 24.5}
+
         """
         scaling_factors = {axis: 1 for axis in self.axis_variables}
 
-        for label in self.svg.get_texts(
-            r"^(?P<axis>x|y)(_scaling_factor|sf)\: (?P<value>-?\d+\.?\d*)"
-        ):
-            scaling_factors[label.axis] = float(label.value)
+        for key in scaling_factors.keys():
+            for label in self.svg.get_texts(
+                f"^(?P<axis>{key})(_scaling_factor|sf)\: (?P<value>-?\d+\.?\d*)"
+            ):
+                scaling_factors[label.axis] = float(label.value)
 
         return scaling_factors
 

--- a/svgdigitizer/svgplot.py
+++ b/svgdigitizer/svgplot.py
@@ -616,7 +616,6 @@ class SVGPlot:
         # Process explicitly marked point on the axes.
 
         for grouped_paths in self._grouped_ref_points.values():
-
             for labeled_path in grouped_paths:
                 label = labeled_path.label
                 point = label.point

--- a/svgdigitizer/svgplot.py
+++ b/svgdigitizer/svgplot.py
@@ -830,7 +830,7 @@ class SVGPlot:
 
         for key in scaling_factors.keys():
             for label in self.svg.get_texts(
-                f"^(?P<axis>{key})(_scaling_factor|sf)\: (?P<value>-?\d+\.?\d*)"
+                fr"^(?P<axis>{key})(_scaling_factor|sf)\: (?P<value>-?\d+\.?\d*)"
             ):
                 scaling_factors[label.axis] = float(label.value)
 

--- a/svgdigitizer/svgplot.py
+++ b/svgdigitizer/svgplot.py
@@ -830,7 +830,7 @@ class SVGPlot:
 
         for key in scaling_factors.keys():
             for label in self.svg.get_texts(
-                fr"^(?P<axis>{key})(_scaling_factor|sf)\: (?P<value>-?\d+\.?\d*)"
+                rf"^(?P<axis>{key})(_scaling_factor|sf)\: (?P<value>-?\d+\.?\d*)"
             ):
                 scaling_factors[label.axis] = float(label.value)
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check. Remove checks that are not relevant and let us know if you need help with any of these.
-->
Checklist
* [x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test for this change. (DOCTEST)
* [x] Updated the documentation. (not necessary)

<!--
Please add any other relevant info below:
-->

Fixes #166 .
Scaling factors for dimensions other than `x` and `y` were not considered.

Dependencies:
- [x] #169 

