### PR TITLE
Remove news for Miniforge usage in the workflows

### DIFF
--- a/doc/news/workflow_miniforge3.rst
+++ b/doc/news/workflow_miniforge3.rst
@@ -1,3 +1,0 @@
-**Changed:**
-
-* Changed workflow setup from Mambaforge to Miniforge3.


### PR DESCRIPTION
The workflows were changed in #217 but are obsolete with the changes introduced in #220. Hence, the news can be deleted.